### PR TITLE
Removing —forceExit from jest test

### DIFF
--- a/__tests__/unit/bundle.spec.js
+++ b/__tests__/unit/bundle.spec.js
@@ -37,7 +37,7 @@ test('Bundle: css minified and jsminified.', () => {
 		jsOutput: 'js',
 	};
 
-	Bundle( data )
+	return Bundle( data )
 		.then( data => expect( data._entriesCount ).toEqual( 3 ) );
 
 });
@@ -50,7 +50,7 @@ test('Bundle: sassModules and react modules.', () => {
 		jsOutput: 'react',
 	};
 
-	Bundle( data )
+	return Bundle( data )
 		.then( data => expect( data._entriesCount ).toEqual( 21 ) );
 
 });
@@ -64,7 +64,7 @@ test('Bundle: cssModules and jsModules with dependencies.', () => {
 		jsOutput: 'jsModules',
 	};
 
-	Bundle( data )
+	return Bundle( data )
 		.then( data => expect( data._entriesCount ).toEqual( 6 ) );
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,37 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
-			"integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
+			"integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-rc.1"
+				"@babel/highlight": "7.0.0-rc.2"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
-			"integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
+			"version": "7.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
+			"integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				}
 			}
 		},
 		"@gov.au/accordion": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/accordion/-/accordion-5.0.1.tgz",
-			"integrity": "sha512-9lSCzshNyxlWdb1JwweDdPA//DTMekHd3BegM+lhO4ei1sqGInY/U5EE5Xl+R9jOP1KE0+Vjk6R1rcFMj3JA5g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/accordion/-/accordion-5.0.2.tgz",
+			"integrity": "sha512-+vUdlxkUa90uRTlA3wRgmeTp7oZcjx6BbnOLRvTc41NB6XgB9TyevOFGsg+2G6YbGQV4G9CRfwugXoEYP+quNQ==",
 			"requires": {
 				"@gov.au/animate": "^1.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -39,9 +47,9 @@
 			}
 		},
 		"@gov.au/animate": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@gov.au/animate/-/animate-1.0.6.tgz",
-			"integrity": "sha512-60yhMLcDo4khVUKn+BQhSd+qY+KvbbW86hNwXqy6X239aBghu0eG9NkapK8Df5JxbuBsQBGZQDeHdzu1x7PUHQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/animate/-/animate-1.0.8.tgz",
+			"integrity": "sha512-07lM2WMD9Uvm9msTR9gUMmLxZRNw1Wtq1phgHiP07Re/qJJeattoe8dWnfaD6+ilTGUqtOK/ZJkTrdP8qZwsuQ==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-js": "~1",
@@ -49,9 +57,9 @@
 			}
 		},
 		"@gov.au/body": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@gov.au/body/-/body-2.0.10.tgz",
-			"integrity": "sha512-zJN1aKQtmxQ1j0zluAptTVzO84gd7rAjhVq2oJxiUWVdW8l97w2/WUCY/hhBmUEqW+8lldwo2MVywM0ikH51lA==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@gov.au/body/-/body-2.0.11.tgz",
+			"integrity": "sha512-I07WUuRlplf1qlmdTI8i8x3B3R+EWxQ3LJJ3v7F0vk3GKkdxsqbDJ32yAi60ZMCe5IphFcdg0IxEFVS3gcNIwQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -60,9 +68,9 @@
 			}
 		},
 		"@gov.au/breadcrumbs": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/breadcrumbs/-/breadcrumbs-3.0.1.tgz",
-			"integrity": "sha512-bPv54Ay/sIlRz4WleTsK5mI3xdNLX1bIT6eahdXjuYmL3Jze1I3Pbz4ypt4vPUCnc5WX+NkHdYkKb+zP88sO9A==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/breadcrumbs/-/breadcrumbs-3.0.2.tgz",
+			"integrity": "sha512-c8xfAtPR3AbxKfTCoxVZtJO0yPU6XJ4/195diWLXnxEcGr4kasAMEPGO09n8AV6ErB7gSIDoSRSP66NaejpEog==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/link-list": "^3.0.0",
@@ -73,9 +81,9 @@
 			}
 		},
 		"@gov.au/buttons": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/buttons/-/buttons-3.0.3.tgz",
-			"integrity": "sha512-OtDBdD6Of0iahyy/FP2NNwoFD1SSZcSBGdPJiN5M8He2ldu2qt0xwmFIYj1jLfEUO711AnjWMAZ7Q+8vMVneyg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/buttons/-/buttons-3.0.4.tgz",
+			"integrity": "sha512-cgQr/zRp/w/+tvsFXXmzC/tDr23jJIfkEO6Z+Jev2uv9SsygbTEybVYDc1R4T4LPOb1Ai++9W4It+RoD1VPDoA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -85,9 +93,9 @@
 			}
 		},
 		"@gov.au/callout": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/callout/-/callout-2.0.7.tgz",
-			"integrity": "sha512-rYlzMybFgwN4nJEJTuQ8oj7zL7rCHBOoF2gytkGsOjMAvSrDx+zZO9Hijalf6xNUHCSikO+IyyBaF7wdXHg/2Q==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/callout/-/callout-2.0.8.tgz",
+			"integrity": "sha512-Y0G64OmulrQZkjmwt7NAds0bBgHxc//NvwrblIRKZQQPLMe8iDdSIkHdUuGjFye/mzFx/fpOGsyPUh1k5CW23Q==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -97,9 +105,9 @@
 			}
 		},
 		"@gov.au/control-input": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/control-input/-/control-input-2.1.5.tgz",
-			"integrity": "sha512-QLb0KpI9nJor2eeORadWRzkVDzkMCYrG3Q1wGhuPemAgjGRDCVtUjnbompDjqCvbz+nzElky3OIAms338wT8Cw==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/control-input/-/control-input-2.1.6.tgz",
+			"integrity": "sha512-vX/AGVERLE6PLMZ3BvkJWTphTp+h+AkOChAAXrlG7NYuZ2wSBZnIIdc/tuU3IfmmsOSLZScF3ScTDkBqIJOlGQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -109,9 +117,9 @@
 			}
 		},
 		"@gov.au/core": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@gov.au/core/-/core-3.0.2.tgz",
-			"integrity": "sha512-eAilHWCJi/Ww3o7OBheAqnZ/EkDrRBrUomrjVWC6Ptlf7voXjxf2q09UkD2oOHnxFJwc21RxfYiJecWmq+wk+A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@gov.au/core/-/core-3.0.3.tgz",
+			"integrity": "sha512-CFKcfKHTL7+vTxSOoOW72DVLMfSohYTzj4ZDlKpA2HTs0KosFWuvcldy5oB9L3/mOH2wqM45q3o1szISnI7bjw==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"@gov.au/pancake-json": "~1",
@@ -120,9 +128,9 @@
 			}
 		},
 		"@gov.au/cta-link": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/cta-link/-/cta-link-2.1.3.tgz",
-			"integrity": "sha512-dJSaNgGtihY1CZ/MxS5QFedoMcT5nzTwhhvFypJmydGb5Xr36w8ZNpGP6F40QeLuJ0IzsFdFMlwG0QWIxCbTjg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/cta-link/-/cta-link-2.1.4.tgz",
+			"integrity": "sha512-WTQCvtjBObBqnQTdmNcnWXJCoYRguyRLVZsVRVv4X3fOXL22088cmQaM8U7o0dWd216ZWTFGrilolpmr7NAiHw==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -132,9 +140,9 @@
 			}
 		},
 		"@gov.au/direction-links": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/direction-links/-/direction-links-2.1.3.tgz",
-			"integrity": "sha512-8eIH0n+ynfDzBHXoTT0SLl5i1DcADEO844ot56R7kSv0PRJUDFTiB8E758cD+zdFjs3yfg0oqrN1hQdyunROdw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/direction-links/-/direction-links-2.1.4.tgz",
+			"integrity": "sha512-h4CQHupCVaj0/zoVcAI6SG0SMIWIQIwJq/1EIoAWPL7fEUQKAo8ofdrKzJjSrNDiDyjjlhP7xv05wm/lBo8WLg==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -144,9 +152,9 @@
 			}
 		},
 		"@gov.au/footer": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/footer/-/footer-2.1.5.tgz",
-			"integrity": "sha512-GugI0Gsu6LWXmvBhcB7/9Wp49WA5RA82V+bMCKSCT34xUHE8pytPhAt9Pjqkfm/65gxdAlyjy5qC/1jsLmnSkQ==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/footer/-/footer-2.1.6.tgz",
+			"integrity": "sha512-iUv0aKg4u93RgrLwKWT2iZR9r/BX3vKN41z3oo2fjcK8QdMuHH7vk6lmyObE7rc7lltiTraIls2rMKvxFbU9IQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -156,9 +164,9 @@
 			}
 		},
 		"@gov.au/grid-12": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/grid-12/-/grid-12-2.0.7.tgz",
-			"integrity": "sha512-igXVVuKZnoM7fvQDgVWC1gbQIdATRWqoC4QSW97GIdeJNj9ZFrIt2DePZJU5NgUvsjVzMa8hgv528j+L6oUkjw==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/grid-12/-/grid-12-2.0.8.tgz",
+			"integrity": "sha512-4SbJ7eTEEuvtceDnSix0rBu049MBy5VNPXTP5kkz373U6owyZATW09Q7BI8lcWrQsAtK16qwiDkhQMBXulEPag==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -167,9 +175,9 @@
 			}
 		},
 		"@gov.au/header": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@gov.au/header/-/header-4.1.5.tgz",
-			"integrity": "sha512-MRKwDkbINGYreck8O0WvOSpFY2MPyDNq7Gm0JbSul/qM5dWidm0+7XziKlFjQRxyQ5vziYgKKol1cbbbF5dRmg==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@gov.au/header/-/header-4.1.6.tgz",
+			"integrity": "sha512-KdnjvlctDcAtx27mxAlziFQ4FwdDfD/rgayvS1LmAL6YC+NnTX5zOQvClt8/mf6rt0UVHXeTmzKqNQ9J+QfdJQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -179,9 +187,9 @@
 			}
 		},
 		"@gov.au/headings": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/headings/-/headings-2.0.7.tgz",
-			"integrity": "sha512-P/JCJDLhrw+8b9PJO1/XUAiVjpFzKJ6Ej0KAFmdkWcX6WNDgcqO04EjwMv1rnt5kFDvrA0n8d0wqoAdKEFRa7Q==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/headings/-/headings-2.0.8.tgz",
+			"integrity": "sha512-C8JmfgrRjdrtEVLIenNVZ1DOMSCIaXwbw+BHzlC6+ncVA3bQr5bmoqu+uNRJCvERIC9WrXmrcAs3EGz65KfEwQ==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -191,9 +199,9 @@
 			}
 		},
 		"@gov.au/inpage-nav": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/inpage-nav/-/inpage-nav-3.0.1.tgz",
-			"integrity": "sha512-BV8q0RR0pMawscPTT9l/w+nivW3E0AckZdf7qzCbEHveZ78jUat4oeqNG3TvIoLfQ+/kQNLGRpTLd4zk6685lA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/inpage-nav/-/inpage-nav-3.0.2.tgz",
+			"integrity": "sha512-H3VzMb8bUdqHHwvEunrrmJ4KktiSHM4ERW0Sko0awQOqz+bog96QvwEuN8S/lZcs9pIxpHX4OMGZec1jIGcJjg==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/link-list": "^3.0.0",
@@ -204,9 +212,9 @@
 			}
 		},
 		"@gov.au/keyword-list": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/keyword-list/-/keyword-list-3.0.1.tgz",
-			"integrity": "sha512-TH0B2D5tGZmhw9QtTjue+SouliOnlBMNYfpSA071n0ftv1u6Que69OEgn0xUb6jqiVR9E+YrGvm/JvQSIkPKNQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/keyword-list/-/keyword-list-3.0.2.tgz",
+			"integrity": "sha512-DzhBlx6j1nmtZ7NittieZAFCbrlvxo/RVrS5qEVgx1BA+ZGhU9ekQ076A5G1PRGprSsFQq+92ZKl1bZX+Vf2Ew==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/link-list": "^3.0.0",
@@ -217,9 +225,9 @@
 			}
 		},
 		"@gov.au/link-list": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@gov.au/link-list/-/link-list-3.0.1.tgz",
-			"integrity": "sha512-8qzRw/JgJ2KyI5ntTNnZvG0y1gxZAV+RJqKqxkXQZirK4J3HASFlijXcNaUMUxeAm7AVZ/P8BO7s4mjhkAeQHg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@gov.au/link-list/-/link-list-3.0.2.tgz",
+			"integrity": "sha512-to72yYbTiKPAPpnjZJ4wqYKz9Be1IaPSG7YB1R3koroIV/MWe4Ox1AkjIbYIESs1wMYlffOg0+YCRs0FEKxtiw==",
 			"requires": {
 				"@gov.au/body": "^2.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -229,10 +237,25 @@
 				"@gov.au/pancake-sass": "~2"
 			}
 		},
+		"@gov.au/main-nav": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/main-nav/-/main-nav-0.1.0.tgz",
+			"integrity": "sha512-8VOOtu5ei43KO6BMBVhGQA02As49T8zmr32rPMoG2QKQ1dTnePfmVWUBzHKAZHQ3XvTTVbUhhNc8uvWGATOdCA==",
+			"requires": {
+				"@gov.au/animate": "^1.0.0",
+				"@gov.au/core": "^3.0.0",
+				"@gov.au/link-list": "^3.0.0",
+				"@gov.au/pancake": "~1",
+				"@gov.au/pancake-js": "~1",
+				"@gov.au/pancake-json": "~1",
+				"@gov.au/pancake-react": "~1",
+				"@gov.au/pancake-sass": "~2"
+			}
+		},
 		"@gov.au/page-alerts": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/page-alerts/-/page-alerts-2.0.7.tgz",
-			"integrity": "sha512-8QuCE8uzHO+ttMJPaBY4MphQ+a0rj/d8ADra/tHov/yqXfYhangvNv3iThjPUE8rURWQvi2aYdC8Ru11o8P/SA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/page-alerts/-/page-alerts-2.0.8.tgz",
+			"integrity": "sha512-jG7cQHLRUvwGyoP3rTzCJ4bg/RMnAFUKubxtTSPKjeO9kZ/FSm+h+7cnlBQwucg3WvszNp+VK8hx0+xwVpxnZQ==",
 			"requires": {
 				"@gov.au/body": "^2.0.0",
 				"@gov.au/core": "^3.0.0",
@@ -243,17 +266,17 @@
 			}
 		},
 		"@gov.au/pancake": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/pancake/-/pancake-1.2.3.tgz",
-			"integrity": "sha512-Mkp7gQjUy5fmEpe1246yXOKSaa/s/A7QDja7gXoFkQcgic3qzJri4dTOcwqtkDZVHLAYfzHOTl5u+NOEW6Noyg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/pancake/-/pancake-1.2.4.tgz",
+			"integrity": "sha512-afLsL+CVTAJ2PO9NPQBgHDV8ZzEF/YOLuEmg8+cBocusDEAShNOzAn3Wmh3MB/MV8E4Ui2OldTRBk9BZStA1WA==",
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
 		},
 		"@gov.au/pancake-js": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@gov.au/pancake-js/-/pancake-js-1.0.12.tgz",
-			"integrity": "sha512-3kkvj84MJfrFXEqZu8/JhNiXzINfEMYwpUa5GUxFGNcejkiZXVb1/dQFiwULJxDZbB0QZysDwWhKyVkoyBG+FA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@gov.au/pancake-js/-/pancake-js-1.0.13.tgz",
+			"integrity": "sha512-FKouUaHsjX8tB1nL7ACr9HbbKp0lfgaGVqyd27vko3XGoGe7qHzEUnKe+FeqjJGkTmw6P1+EZmFtcNpjsLPbIg==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"babel-runtime": "6.26.0",
@@ -272,33 +295,33 @@
 			}
 		},
 		"@gov.au/pancake-json": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@gov.au/pancake-json/-/pancake-json-1.0.6.tgz",
-			"integrity": "sha512-s8B0EKJbKrK4qbwEJEJw9oDsUnhvoTJwqkEUKsVZBYz4Ck/+pKHrsizXEllfjq+l3YuNERvqIWnS86Wt/B0G6Q==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@gov.au/pancake-json/-/pancake-json-1.0.7.tgz",
+			"integrity": "sha512-xIrusesWBuisHmHmX+zrXo1DdBkcekzalygshT/c3K+52TWmu0BcIuYIo6M8OXyPrfRTDbvDjwyeBIa6YFU+gg==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"babel-runtime": "6.26.0"
 			}
 		},
 		"@gov.au/pancake-react": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/pancake-react/-/pancake-react-1.1.3.tgz",
-			"integrity": "sha512-LWGhSV1S8sJqLgbE3HVojjKJGW9koS4kBFvUxcNMNXcBZ7OebNVgAo21GUXKhesAdPGb62VeV4shfRQPdULLeQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/pancake-react/-/pancake-react-1.1.4.tgz",
+			"integrity": "sha512-VPIU+L4O7vzMwiEH4SOm0OXZ97wIahrFQ4RMuxSTXOVM6hkyrinb0hBfqYadUtJNWmmY/ZByP6hNz0l9fvTK0A==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"babel-runtime": "6.26.0"
 			}
 		},
 		"@gov.au/pancake-sass": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@gov.au/pancake-sass/-/pancake-sass-2.0.0.tgz",
-			"integrity": "sha512-IjUxKpa8cV84I71KtS9KqAQeKL0Q2vchupxRE7+qWZOlhTwcmiSGkYnM4z3siI7i/xJVlEzgVUz8ZSh7J/Mpow==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@gov.au/pancake-sass/-/pancake-sass-2.1.0.tgz",
+			"integrity": "sha512-kjwuYaCzU7pTD/mj6/J3TRAtldExhW1cKBHxZ5BGAU/BOYJ2ve2vq4lzbq8tA+P7OMYSc2BE1qP+5H/N9kAwcA==",
 			"requires": {
 				"@gov.au/pancake": "~1",
 				"autoprefixer": "7.1.6",
 				"babel-runtime": "6.26.0",
-				"postcss": "6.0.14",
-				"sass": "^1.6.0"
+				"node-sass": "^4.9.3",
+				"postcss": "6.0.14"
 			},
 			"dependencies": {
 				"autoprefixer": {
@@ -327,9 +350,9 @@
 			}
 		},
 		"@gov.au/progress-indicator": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/progress-indicator/-/progress-indicator-3.1.3.tgz",
-			"integrity": "sha512-y3B3nA74acj57g+Zr8ft6yadz/7jZPxMl2bM0Ezh5r3JURuK88q8DGiJZ4KOsaFuzaJkFqe8n2kWGUoDEUGMoQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/progress-indicator/-/progress-indicator-3.1.4.tgz",
+			"integrity": "sha512-EQPw8V++vl+ZBm3l60aLhCVSLXyURZtNrhWNdKc7RD0UWt/66erAHhg3HFJmwuJPzDnuWe9NgufKpQ/M9jiYmw==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -339,9 +362,9 @@
 			}
 		},
 		"@gov.au/responsive-media": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@gov.au/responsive-media/-/responsive-media-2.0.10.tgz",
-			"integrity": "sha512-suv0AeSHYzfXfFAguzsX5d3ik7afLnE5e/jRUbLe7tVALUgWkvhmSKjyfj6TXP0ugGaLdhXjqRJ6UStfwSPFbA==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@gov.au/responsive-media/-/responsive-media-2.0.11.tgz",
+			"integrity": "sha512-9MMbJnkceEBqv7GXMJFwf9RDBQuWOekPV/DLFmWbfvfzunfvRKfDGXzhOSQM2xoCoXmZNA+TbVoQ4W0whaLwng==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -350,9 +373,9 @@
 			}
 		},
 		"@gov.au/select": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@gov.au/select/-/select-2.0.7.tgz",
-			"integrity": "sha512-NIecblqrwO5qseeBbHmWE2V3UNwxrvKN4BNgIbrRQhnmoMZAvRRj3zlJ46wVLolAzoAlHE1GkHxc5WnJ56AVyw==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@gov.au/select/-/select-2.0.8.tgz",
+			"integrity": "sha512-wZAmKx2iqElhGUs3awmrPVLIUtNZL1na/m5xV72CIWP2MmhWNAelR0gUDi2J6EeitQmsWXRBqCZ8+r18JVz1uA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -362,9 +385,9 @@
 			}
 		},
 		"@gov.au/side-nav": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/side-nav/-/side-nav-2.0.3.tgz",
-			"integrity": "sha512-GcdMnJdrSH2AByMIUq+YlmQONPHYh2lBKDszrbviEdJZxRTxw1cQW/f0RiOrnAT67ZAKMpFR/myUwxoyujT/0g==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/side-nav/-/side-nav-2.0.4.tgz",
+			"integrity": "sha512-Y0Tmrqbckq9X+CKe9McSwc4scCXEdSDouAKH2SpjU6ey0HfpeVZ6LjRr3PihUf8DqBHGs5nfx5Dap38hl+S/oA==",
 			"requires": {
 				"@gov.au/accordion": "^5.0.0",
 				"@gov.au/animate": "^1.0.0",
@@ -378,9 +401,9 @@
 			}
 		},
 		"@gov.au/skip-link": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@gov.au/skip-link/-/skip-link-2.0.8.tgz",
-			"integrity": "sha512-PqrQL5qyMH3vwU+Zeycs5bhZOjeF4Gwij0O0t8L+D6QhbCwLtCpzPxbtRs3YeTZUOhBXiQgO8m4e8RZKVaRSQw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@gov.au/skip-link/-/skip-link-2.0.9.tgz",
+			"integrity": "sha512-7gzybZDl48OJDOpu/H5exLmYQVXCsLa7NTehp7LYTzaWYlDLcuvWnZ/MFQzKBL8I3KxP48bT781ErR42Ls9JWA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -390,9 +413,9 @@
 			}
 		},
 		"@gov.au/tags": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@gov.au/tags/-/tags-3.1.3.tgz",
-			"integrity": "sha512-5iYkbIqefP88y+/clzbS+BNmL8I6JnMFlM/5VhyFzd7T+NStMUCP41wGWL+tEym+H1oqPRanWFnrHBs2ycq+eQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@gov.au/tags/-/tags-3.1.4.tgz",
+			"integrity": "sha512-YqRZTfUePpDQkLPnZJOYO2QzIG8IPuuQF/zWu9UFJQiwMak5gnrhzLCZnHga8UfBjWbaNImfISiAOszv6R9dtA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -402,9 +425,9 @@
 			}
 		},
 		"@gov.au/text-inputs": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@gov.au/text-inputs/-/text-inputs-2.0.8.tgz",
-			"integrity": "sha512-USbfNulE6uTrsohugx7iVWNwWK4aXG0KpDqWlyraYvSMvOoo7RBrbSt1CVVQtl/zT2v2h0KrC/Xyt8llYSareA==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@gov.au/text-inputs/-/text-inputs-2.0.9.tgz",
+			"integrity": "sha512-AimytddoQuit3uBudklQ7UbPGe6/KPrLH2bkQgKmCYttF6WrXyDbqeyZnzutuXB3y04u9rPwuUaaovT8RxmuCA==",
 			"requires": {
 				"@gov.au/core": "^3.0.0",
 				"@gov.au/pancake": "~1",
@@ -419,23 +442,21 @@
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
 		"@slack/client": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@slack/client/-/client-4.3.1.tgz",
-			"integrity": "sha512-4tA//6EWBjXNIVViKlQxAi1MU0l/kMUC/DO/JdEJNwnNyVKdimAcBrOvMLlRaxk1Cqc12iQmHjmoKyavhvnC5Q==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@slack/client/-/client-4.4.0.tgz",
+			"integrity": "sha512-DjcuktS+9I1IxYxOwY1ZcndpN44smKXkJJ7cLveevxWpZDDRcLmT0XTznGTfTKhC0+eCehSOcUcqCeZfBdoNYg==",
 			"requires": {
-				"@types/delay": "^2.0.1",
 				"@types/form-data": "^2.2.1",
 				"@types/got": "^7.1.7",
 				"@types/is-stream": "^1.1.0",
 				"@types/loglevel": "^1.5.3",
-				"@types/node": "^9.4.7",
+				"@types/node": ">=6.0.0",
 				"@types/p-cancelable": "^0.3.0",
 				"@types/p-queue": "^2.3.1",
 				"@types/p-retry": "^1.0.1",
 				"@types/retry": "^0.10.2",
 				"@types/url-join": "^0.8.2",
 				"@types/ws": "^5.1.1",
-				"delay": "^2.0.0",
 				"eventemitter3": "^3.0.0",
 				"finity": "^0.5.4",
 				"form-data": "^2.3.1",
@@ -447,16 +468,11 @@
 				"object.values": "^1.0.4",
 				"p-cancelable": "^0.3.0",
 				"p-queue": "^2.3.0",
-				"p-retry": "^1.0.0",
-				"retry": "^0.10.1",
+				"p-retry": "^2.0.0",
+				"retry": "^0.12.0",
 				"url-join": "^4.0.0",
 				"ws": "^5.2.0"
 			}
-		},
-		"@types/delay": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/delay/-/delay-2.0.1.tgz",
-			"integrity": "sha512-D1/YuYOcdOIdaQnaiUJ77VcilVvESkynw79CtGqpjkXyv4OUezEVZtdXnSOwXL8Zcelu66QbyC8QQcVQ/ZPdig=="
 		},
 		"@types/events": {
 			"version": "1.2.0",
@@ -493,9 +509,9 @@
 			"integrity": "sha512-TzzIZihV+y9kxSg5xJMkyIkaoGkXi50isZTtGHObNHRqAAwjGNjSCNPI7AUAv0tZUKTq9f2cdkCUd/2JVZUTrA=="
 		},
 		"@types/node": {
-			"version": "9.6.26",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.26.tgz",
-			"integrity": "sha512-3LKKscYUZdZreOuvnly8oWsCA1TOWtmkV3mbcUnV34f+nqDWJic+4SGjRi1C/sPHnZcSs/x209O+Dgy8aWHt2A=="
+			"version": "10.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
+			"integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
 		},
 		"@types/p-cancelable": {
 			"version": "0.3.0",
@@ -574,6 +590,17 @@
 			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
 			"integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
 			"dev": true
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -664,12 +691,14 @@
 			}
 		},
 		"anymatch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"optional": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
 			}
 		},
 		"append-transform": {
@@ -733,19 +762,25 @@
 			}
 		},
 		"arr-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.0.1"
+			}
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -779,9 +814,10 @@
 			"dev": true
 		},
 		"array-unique": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -797,10 +833,16 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"astral-regex": {
 			"version": "1.0.0",
@@ -819,7 +861,8 @@
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
 		},
 		"async-foreach": {
 			"version": "0.1.3",
@@ -837,9 +880,10 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
 		},
 		"autoprefixer": {
 			"version": "7.2.6",
@@ -853,6 +897,11 @@
 				"postcss": "^6.0.17",
 				"postcss-value-parser": "^3.2.3"
 			}
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.8.0",
@@ -882,141 +931,6 @@
 				"v8flags": "^2.1.1"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"micromatch": "^2.1.5",
-						"normalize-path": "^2.0.0"
-					}
-				},
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true,
-					"optional": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"chokidar": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"anymatch": "^1.3.0",
-						"async-each": "^1.0.0",
-						"fsevents": "^1.0.0",
-						"glob-parent": "^2.0.0",
-						"inherits": "^2.0.1",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^2.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"glob-parent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-glob": "^2.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1264,6 +1178,46 @@
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
@@ -1645,6 +1599,7 @@
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -1655,39 +1610,11 @@
 				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -1708,7 +1635,8 @@
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true
 		},
 		"bl": {
 			"version": "1.2.2",
@@ -1808,30 +1736,14 @@
 			}
 		},
 		"braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"browser-process-hrtime": {
@@ -1920,6 +1832,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -1930,6 +1843,14 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"cacheable-request": {
@@ -1983,9 +1904,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000874",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
-			"integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w=="
+			"version": "1.0.30000878",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+			"integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
 		},
 		"capture-exit": {
 			"version": "1.2.0",
@@ -2041,9 +1962,9 @@
 			},
 			"dependencies": {
 				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -2076,35 +1997,34 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
+			"optional": true,
 			"requires": {
-				"anymatch": "^2.0.0",
+				"anymatch": "^1.3.0",
 				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
-				"glob-parent": "^3.1.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
+				"is-glob": "^2.0.0",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"readdirp": "^2.0.0"
 			}
 		},
 		"ci-info": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
+			"integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
 			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -2116,9 +2036,73 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
 			}
 		},
@@ -2160,6 +2144,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -2200,7 +2185,8 @@
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"compress-commons": {
 			"version": "1.2.2",
@@ -2275,7 +2261,8 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"copy-dir": {
 			"version": "0.3.0",
@@ -2366,13 +2353,6 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"data-urls": {
@@ -2455,49 +2435,19 @@
 			}
 		},
 		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				}
+				"is-descriptor": "^1.0.0"
 			}
 		},
 		"del": {
@@ -2512,14 +2462,14 @@
 				"p-map": "^1.1.1",
 				"pify": "^3.0.0",
 				"rimraf": "^2.2.8"
-			}
-		},
-		"delay": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/delay/-/delay-2.0.0.tgz",
-			"integrity": "sha1-kRLq3APk7H4AKXM3iW8nO72R+uU=",
-			"requires": {
-				"p-defer": "^1.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"delayed-stream": {
@@ -2622,9 +2572,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.55",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.55.tgz",
-			"integrity": "sha1-8VDhCyC3fZ1Br8yjEu/gw7Gn/c4="
+			"version": "1.3.59",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+			"integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -2784,35 +2734,12 @@
 			"dev": true
 		},
 		"expand-brackets": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -2822,48 +2749,6 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
-					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"expect": {
@@ -2999,6 +2884,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -3008,6 +2894,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -3015,62 +2902,12 @@
 			}
 		},
 		"extglob": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				}
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -3120,22 +2957,34 @@
 			}
 		},
 		"fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			},
 			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"kind-of": "^3.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -3178,7 +3027,8 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
@@ -3188,11 +3038,6 @@
 			"requires": {
 				"for-in": "^1.0.1"
 			}
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -3218,6 +3063,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -3262,6 +3108,7 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -3270,25 +3117,25 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -3297,13 +3144,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3311,35 +3158,35 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3347,26 +3194,26 @@
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -3374,14 +3221,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -3396,8 +3243,8 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -3410,14 +3257,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -3425,8 +3272,8 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -3434,8 +3281,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -3444,46 +3291,46 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true,
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3491,8 +3338,8 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -3500,22 +3347,22 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -3525,8 +3372,8 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -3543,8 +3390,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -3553,14 +3400,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -3569,8 +3416,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -3581,39 +3428,39 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -3622,20 +3469,20 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -3646,16 +3493,16 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -3669,8 +3516,8 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -3678,43 +3525,43 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+					"bundled": true,
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3723,8 +3570,8 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -3732,22 +3579,22 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -3761,14 +3608,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -3776,13 +3623,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
@@ -3843,7 +3690,8 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -3851,13 +3699,6 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"glob": {
@@ -3881,51 +3722,15 @@
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"glob-parent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^2.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"glob-parent": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
-			},
-			"dependencies": {
-				"is-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"requires": {
-						"is-extglob": "^2.1.0"
-					}
-				}
+				"is-glob": "^2.0.0"
 			}
 		},
 		"global-dirs": {
@@ -3953,14 +3758,6 @@
 				"object-assign": "^4.0.1",
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
 			}
 		},
 		"globule": {
@@ -4001,6 +3798,11 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
 					"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -4111,6 +3913,20 @@
 				}
 			}
 		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"requires": {
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
+			}
+		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4154,16 +3970,26 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
 				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -4173,6 +3999,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -4226,6 +4053,16 @@
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
 				"statuses": ">= 1.4.0 < 2"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -4330,21 +4167,11 @@
 			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
 		"is-accessor-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 			"requires": {
-				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
+				"kind-of": "^6.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -4356,6 +4183,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -4379,30 +4207,20 @@
 			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
+			"integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "^1.3.0"
 			}
 		},
 		"is-data-descriptor": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 			"requires": {
-				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
+				"kind-of": "^6.0.0"
 			}
 		},
 		"is-date-object": {
@@ -4411,20 +4229,13 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
+				"is-accessor-descriptor": "^1.0.0",
+				"is-data-descriptor": "^1.0.0",
+				"kind-of": "^6.0.2"
 			}
 		},
 		"is-dotfile": {
@@ -4445,12 +4256,14 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -4475,11 +4288,12 @@
 			"dev": true
 		},
 		"is-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
-				"is-extglob": "^2.1.1"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-installed-globally": {
@@ -4568,8 +4382,17 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"is-posix-bracket": {
@@ -4634,7 +4457,8 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -4647,9 +4471,13 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -4842,32 +4670,6 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -4885,24 +4687,6 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -4912,55 +4696,20 @@
 						"locate-path": "^2.0.0"
 					}
 				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"os-locale": {
@@ -4973,6 +4722,36 @@
 						"lcid": "^1.0.0",
 						"mem": "^1.1.0"
 					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -5050,97 +4829,6 @@
 				"jest-validate": "^23.5.0",
 				"micromatch": "^2.3.11",
 				"pretty-format": "^23.5.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
 			}
 		},
 		"jest-diff": {
@@ -5215,97 +4903,6 @@
 				"jest-worker": "^23.2.0",
 				"micromatch": "^2.3.11",
 				"sane": "^2.0.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
 			}
 		},
 		"jest-jasmine2": {
@@ -5359,97 +4956,6 @@
 				"micromatch": "^2.3.11",
 				"slash": "^1.0.0",
 				"stack-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
 			}
 		},
 		"jest-mock": {
@@ -5553,32 +5059,6 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -5596,24 +5076,6 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -5623,55 +5085,20 @@
 						"locate-path": "^2.0.0"
 					}
 				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"os-locale": {
@@ -5684,6 +5111,36 @@
 						"lcid": "^1.0.0",
 						"mem": "^1.1.0"
 					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -5919,13 +5376,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"keyv": {
@@ -6011,21 +5461,14 @@
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0",
 				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				}
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			},
 			"dependencies": {
@@ -6054,7 +5497,8 @@
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
@@ -6129,6 +5573,14 @@
 			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"makeerror": {
@@ -6143,7 +5595,8 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-obj": {
 			"version": "1.0.1",
@@ -6160,6 +5613,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -6226,23 +5680,35 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"mime": {
@@ -6290,6 +5756,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -6299,6 +5766,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -6340,6 +5808,7 @@
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -6352,6 +5821,36 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"natural-compare": {
@@ -6418,9 +5917,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
-			"integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -6435,7 +5934,7 @@
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"nan": "^2.10.0",
-				"node-gyp": "^3.3.1",
+				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "2.87.0",
 				"sass-graph": "^2.2.4",
@@ -6460,10 +5959,59 @@
 						"supports-color": "^2.0.0"
 					}
 				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"request": {
+					"version": "2.87.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+					"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
+					}
+				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"tough-cookie": {
+					"version": "2.3.4",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"requires": {
+						"punycode": "^1.4.1"
+					}
 				}
 			}
 		},
@@ -6485,6 +6033,78 @@
 				"update-notifier": "^2.3.0"
 			},
 			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"chokidar": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+					"dev": true,
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.2.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"lodash.debounce": "^4.0.8",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.5"
+					}
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -6494,10 +6114,243 @@
 						"ms": "2.0.0"
 					}
 				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"dev": true,
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
 				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -6583,9 +6436,9 @@
 			"dev": true
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -6596,6 +6449,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -6606,14 +6460,53 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
 					}
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6629,8 +6522,17 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"object.entries": {
@@ -6667,8 +6569,17 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"object.values": {
@@ -6781,11 +6692,6 @@
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
 			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -6797,19 +6703,19 @@
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+			"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
 		"p-map": {
@@ -6824,11 +6730,11 @@
 			"integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
 		},
 		"p-retry": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
-			"integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+			"integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
 			"requires": {
-				"retry": "^0.10.0"
+				"retry": "^0.12.0"
 			}
 		},
 		"p-timeout": {
@@ -6840,9 +6746,9 @@
 			}
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"package-json": {
 			"version": "4.0.1",
@@ -6910,23 +6816,6 @@
 				"is-dotfile": "^1.0.0",
 				"is-extglob": "^1.0.0",
 				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"parse-json": {
@@ -6960,7 +6849,8 @@
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
 		},
 		"path-case": {
 			"version": "2.1.1",
@@ -6973,7 +6863,8 @@
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "2.1.0",
@@ -7018,13 +6909,6 @@
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				}
 			}
 		},
 		"pause-stream": {
@@ -7036,10 +6920,15 @@
 				"through": "~2.3"
 			}
 		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
 		"pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -7071,6 +6960,46 @@
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
@@ -7083,7 +7012,8 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"postcss": {
 			"version": "6.0.23",
@@ -7096,9 +7026,9 @@
 			},
 			"dependencies": {
 				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7188,6 +7118,11 @@
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
+		"psl": {
+			"version": "1.1.29",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+		},
 		"pstree.remy": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
@@ -7218,9 +7153,9 @@
 			}
 		},
 		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
 			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
@@ -7301,6 +7236,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"minimatch": "^3.0.2",
@@ -7359,6 +7295,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -7412,14 +7349,16 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -7430,13 +7369,13 @@
 			}
 		},
 		"replace-in-file": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-3.4.0.tgz",
-			"integrity": "sha512-fto9Ooab00CniGkSjRCZCamER7P5S4mZHQ4w4dLd09nwP3FtFfjUJh8/OVC/In4ki5MEy+dYO5v9r7rtq2DrYQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-3.4.2.tgz",
+			"integrity": "sha512-wb2EU5MBBqUty+b1xSIqa0IKs5M2/a+4Ldw8KM5Gpe1btv16K0eii6nMxyNhAmRZhCEPrge0ss5Ij9f7vJEYcw==",
 			"requires": {
-				"chalk": "^2.3.2",
+				"chalk": "^2.4.1",
 				"glob": "^7.1.2",
-				"yargs": "^11.0.0"
+				"yargs": "^12.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7459,12 +7398,20 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+				"decamelize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
 					"requires": {
-						"locate-path": "^2.0.0"
+						"xregexp": "4.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -7505,13 +7452,13 @@
 					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"version": "12.0.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+					"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
 					"requires": {
 						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
+						"decamelize": "^2.0.0",
+						"find-up": "^3.0.0",
 						"get-caller-file": "^1.0.1",
 						"os-locale": "^2.0.0",
 						"require-directory": "^2.1.1",
@@ -7519,14 +7466,14 @@
 						"set-blocking": "^2.0.0",
 						"string-width": "^2.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^10.1.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -7534,82 +7481,30 @@
 			}
 		},
 		"request": {
-			"version": "2.87.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
+				"aws4": "^1.8.0",
 				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				},
-				"aws-sign2": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-				},
-				"har-schema": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-				},
-				"har-validator": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-					"requires": {
-						"ajv": "^5.1.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"http-signature": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
-				},
-				"performance-now": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-				}
+				"uuid": "^3.3.2"
 			}
 		},
 		"request-promise-core": {
@@ -7666,7 +7561,8 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
 		},
 		"responselike": {
 			"version": "1.0.2",
@@ -7679,12 +7575,13 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"retry": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
 		},
 		"right-align": {
 			"version": "0.1.3",
@@ -7719,6 +7616,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -7743,14 +7641,247 @@
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5",
 				"watch": "~0.18.0"
-			}
-		},
-		"sass": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.10.3.tgz",
-			"integrity": "sha512-6ZOovA5xNZ19epFifIqqC8befpyZgXw8uygiW3v+IdHAE24catMGHcXltdEX1Hk5lHDY7gzapBHXQfIO3hnluQ==",
-			"requires": {
-				"chokidar": "^2.0.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
 			}
 		},
 		"sass-graph": {
@@ -7795,9 +7926,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
 		},
 		"semver-diff": {
 			"version": "2.1.0",
@@ -7863,12 +7994,14 @@
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -7880,6 +8013,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -7939,6 +8073,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -7954,6 +8089,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -7962,14 +8098,73 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -7977,45 +8172,18 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
 				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -8023,6 +8191,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -8031,6 +8200,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8054,6 +8224,7 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -8082,7 +8253,8 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
@@ -8125,6 +8297,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -8149,13 +8322,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"stack-utils": {
@@ -8168,6 +8334,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -8177,9 +8344,67 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
 			}
 		},
@@ -8370,6 +8595,237 @@
 				"object-assign": "^4.1.0",
 				"read-pkg-up": "^1.0.1",
 				"require-main-filename": "^1.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
 			}
 		},
 		"throat": {
@@ -8418,6 +8874,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -8426,6 +8883,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8436,17 +8894,37 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
 				"regex-not": "^1.0.2",
 				"safe-regex": "^1.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -8473,10 +8951,11 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
+				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
 			}
 		},
@@ -8563,9 +9042,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.4.6",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
-			"integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+			"integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
 			"requires": {
 				"commander": "~2.16.0",
 				"source-map": "~0.6.1"
@@ -8598,6 +9077,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -8609,6 +9089,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -8617,6 +9098,7 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -8644,6 +9126,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -8653,6 +9136,7 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -8663,6 +9147,7 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -8672,7 +9157,14 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -8685,7 +9177,8 @@
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"dev": true
 		},
 		"update-notifier": {
 			"version": "2.5.0",
@@ -8721,7 +9214,8 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"url-join": {
 			"version": "4.0.0",
@@ -8744,7 +9238,8 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
@@ -8808,13 +9303,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"w3c-hr-time": {
@@ -8947,42 +9435,6 @@
 			"requires": {
 				"define-property": "^1.0.0",
 				"is-number": "^3.0.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				}
 			}
 		},
 		"wordwrap": {
@@ -9035,6 +9487,11 @@
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
+		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-			"integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+			"integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.56"
+				"@babel/highlight": "7.0.0-rc.1"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.56",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-			"integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
+			"version": "7.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+			"integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
@@ -362,9 +362,9 @@
 			}
 		},
 		"@gov.au/side-nav": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@gov.au/side-nav/-/side-nav-2.0.2.tgz",
-			"integrity": "sha512-KTdICWSOMz4Otts7i6jmhzPBM95nvxe5jqhvpG0UNf08iwIRr1xmfT/TavCEQpZlmZrf+JLrzyxy/DwjoCmxfQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@gov.au/side-nav/-/side-nav-2.0.3.tgz",
+			"integrity": "sha512-GcdMnJdrSH2AByMIUq+YlmQONPHYh2lBKDszrbviEdJZxRTxw1cQW/f0RiOrnAT67ZAKMpFR/myUwxoyujT/0g==",
 			"requires": {
 				"@gov.au/accordion": "^5.0.0",
 				"@gov.au/animate": "^1.0.0",
@@ -574,15 +574,6 @@
 			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
 			"integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
 			"dev": true
-		},
-		"ajv": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-			"requires": {
-				"co": "^4.6.0",
-				"json-stable-stringify": "^1.0.1"
-			}
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -806,11 +797,6 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
-		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -867,11 +853,6 @@
 				"postcss": "^6.0.17",
 				"postcss-value-parser": "^3.2.3"
 			}
-		},
-		"aws-sign2": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
 		},
 		"aws4": {
 			"version": "1.8.0",
@@ -1763,14 +1744,6 @@
 				"type-is": "~1.6.16"
 			}
 		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"requires": {
-				"hoek": "2.x.x"
-			}
-		},
 		"boxen": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -2219,9 +2192,9 @@
 			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
 		},
 		"compare-versions": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-			"integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz",
+			"integrity": "sha512-GkIcfJ9sDt4+gS+RWH3X+kR7ezuKdu3fg2oA9nRA8HZoqZwAKv3ml3TyfB9OyV2iFXxCw7q5XfV6SyPbSCT2pw==",
 			"dev": true
 		},
 		"component-emitter": {
@@ -2358,14 +2331,6 @@
 				"which": "^1.2.9"
 			}
 		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"requires": {
-				"boom": "2.x.x"
-			}
-		},
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -2379,9 +2344,9 @@
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.0.0.tgz",
-			"integrity": "sha512-Bpuh47j2mRMY60X90mXaJAEtJwxvA2roZzbgwAXYhMbmwmakdRr4Cq9L5SkleKJNLOKqHIa2YWyOXDX3VgggSQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -2411,21 +2376,26 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
+			"integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"whatwg-mimetype": "^2.0.0",
-				"whatwg-url": "^6.4.0"
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^7.0.0"
 			},
 			"dependencies": {
-				"abab": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-					"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-					"dev": true
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
 				}
 			}
 		},
@@ -2897,15 +2867,15 @@
 			}
 		},
 		"expect": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-			"integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.5.0.tgz",
+			"integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.2.0",
+				"jest-diff": "^23.5.0",
 				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-matcher-utils": "^23.5.0",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0"
 			}
@@ -3300,21 +3270,25 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -3323,11 +3297,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3335,29 +3311,35 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3365,22 +3347,26 @@
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -3388,12 +3374,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -3408,7 +3396,8 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -3421,12 +3410,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -3434,7 +3425,8 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -3442,7 +3434,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -3451,39 +3444,46 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"minipass": {
 					"version": "2.2.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3491,7 +3491,8 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -3499,19 +3500,22 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -3521,7 +3525,8 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -3538,7 +3543,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -3547,12 +3553,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -3561,7 +3569,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -3572,33 +3581,39 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -3607,17 +3622,20 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -3628,14 +3646,16 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -3649,7 +3669,8 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -3657,36 +3678,43 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3695,7 +3723,8 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -3703,19 +3732,22 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -3729,12 +3761,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -3742,11 +3776,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
 				}
 			}
 		},
@@ -4075,20 +4111,6 @@
 				}
 			}
 		},
-		"har-schema": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-		},
-		"har-validator": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-			"requires": {
-				"ajv": "^4.9.1",
-				"har-schema": "^1.0.5"
-			}
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4157,17 +4179,6 @@
 				}
 			}
 		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.x.x",
-				"cryptiles": "2.x.x",
-				"hoek": "2.x.x",
-				"sntp": "1.x.x"
-			}
-		},
 		"header-case": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
@@ -4176,11 +4187,6 @@
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.3"
 			}
-		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
@@ -4220,16 +4226,6 @@
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
 				"statuses": ">= 1.4.0 < 2"
-			}
-		},
-		"http-signature": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-			"requires": {
-				"assert-plus": "^0.2.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -4797,9 +4793,9 @@
 			}
 		},
 		"jest-cli": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.2.tgz",
-			"integrity": "sha512-vaDzy0wRWrgSfz4ZImCqD2gtZqCSoEWp60y3USvGDxA2b4K0rGj2voru6a5scJFjDx5GCiNWKpz2E8IdWDVjdw==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.5.0.tgz",
+			"integrity": "sha512-Kxi2QH8s6NkpPgboza/plpmQ2bjUQ+MwYv7vM5rDwJz/x+NB4YoLXFikPXLWNP0JuYpMvYwITKneFljnNKhq2Q==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
@@ -4814,18 +4810,18 @@
 				"istanbul-lib-instrument": "^1.10.1",
 				"istanbul-lib-source-maps": "^1.2.4",
 				"jest-changed-files": "^23.4.2",
-				"jest-config": "^23.4.2",
+				"jest-config": "^23.5.0",
 				"jest-environment-jsdom": "^23.4.0",
 				"jest-get-type": "^22.1.0",
-				"jest-haste-map": "^23.4.1",
+				"jest-haste-map": "^23.5.0",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve-dependencies": "^23.4.2",
-				"jest-runner": "^23.4.2",
-				"jest-runtime": "^23.4.2",
-				"jest-snapshot": "^23.4.2",
+				"jest-resolve-dependencies": "^23.5.0",
+				"jest-runner": "^23.5.0",
+				"jest-runtime": "^23.5.0",
+				"jest-snapshot": "^23.5.0",
 				"jest-util": "^23.4.0",
-				"jest-validate": "^23.4.0",
+				"jest-validate": "^23.5.0",
 				"jest-watcher": "^23.4.0",
 				"jest-worker": "^23.2.0",
 				"micromatch": "^2.3.11",
@@ -5035,9 +5031,9 @@
 			}
 		},
 		"jest-config": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-			"integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.5.0.tgz",
+			"integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
@@ -5047,24 +5043,116 @@
 				"jest-environment-jsdom": "^23.4.0",
 				"jest-environment-node": "^23.4.0",
 				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.4.2",
+				"jest-jasmine2": "^23.5.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.1",
+				"jest-resolve": "^23.5.0",
 				"jest-util": "^23.4.0",
-				"jest-validate": "^23.4.0",
-				"pretty-format": "^23.2.0"
+				"jest-validate": "^23.5.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.5.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				}
 			}
 		},
 		"jest-diff": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-			"integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+			"integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"diff": "^3.2.0",
 				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-docblock": {
@@ -5077,13 +5165,13 @@
 			}
 		},
 		"jest-each": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.4.0.tgz",
-			"integrity": "sha1-L6nt2J2qGk7cn/m/YGKja3E0UUM=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.5.0.tgz",
+			"integrity": "sha512-8BgebQgAJmWXpYp4Qt9l3cn1Xei0kZ7JL4cs/NXh7750ATlPGzRRYbutFVJTk5B/Lt3mjHP3G3tLQLyBOCSHGA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -5114,13 +5202,14 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "23.4.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.1.tgz",
-			"integrity": "sha512-PGQxOEGAfRbTyJkmZeOKkVSs+KVeWgG625p89KUuq+sIIchY5P8iPIIc+Hw2tJJPBzahU3qopw1kF/qyhDdNBw==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.5.0.tgz",
+			"integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
 			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
+				"invariant": "^2.2.4",
 				"jest-docblock": "^23.2.0",
 				"jest-serializer": "^23.0.1",
 				"jest-worker": "^23.2.0",
@@ -5220,43 +5309,43 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-			"integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz",
+			"integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
 			"dev": true,
 			"requires": {
 				"babel-traverse": "^6.0.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^23.4.0",
+				"expect": "^23.5.0",
 				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.2.0",
-				"jest-each": "^23.4.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-diff": "^23.5.0",
+				"jest-each": "^23.5.0",
+				"jest-matcher-utils": "^23.5.0",
 				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.4.2",
+				"jest-snapshot": "^23.5.0",
 				"jest-util": "^23.4.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
-			"integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz",
+			"integrity": "sha512-40VsHQCIEslxg91Zg5NiZGtPeWSBLXiD6Ww+lhHlIF6u8uSQ+xgiD6NbWHFOYs1VBRI+V/ym7Q1aOtVg9tqMzQ==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-			"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+			"integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-message-util": {
@@ -5376,9 +5465,9 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "23.4.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-			"integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+			"integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
 			"dev": true,
 			"requires": {
 				"browser-resolve": "^1.11.3",
@@ -5387,30 +5476,30 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz",
-			"integrity": "sha512-JUrU1/1mQAf0eKwKT4+RRnaqcw0UcRzRE38vyO+YnqoXUVidf646iuaKE+NG7E6Gb0+EVPOJ6TgqkaTPdQz78A==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.5.0.tgz",
+			"integrity": "sha512-APZc/CjfzL8rH/wr+Gh7XJJygYaDjMQsWaJy4ZR1WaHWKude4WcfdU8xjqaNbx5NsVF2P2tVvsLbumlPXCdJOw==",
 			"dev": true,
 			"requires": {
 				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.4.2"
+				"jest-snapshot": "^23.5.0"
 			}
 		},
 		"jest-runner": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.2.tgz",
-			"integrity": "sha512-o+aEdDE7/Gyp8fLYEEf5B8aOUguz76AYcAMl5pueucey2Q50O8uUIXJ7zvt8O6OEJDztR3Kb+osMoh8MVIqgTw==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.5.0.tgz",
+			"integrity": "sha512-cpBvkBTVmW1ab1thbtoh2m6VnnM0BYKhj3MEzbOTZjPfzoIjUVIxLUTDobVNOvEK7aTEb/2oiPlNoOTSNJx8mw==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.2",
+				"jest-config": "^23.5.0",
 				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.4.1",
-				"jest-jasmine2": "^23.4.2",
-				"jest-leak-detector": "^23.2.0",
+				"jest-haste-map": "^23.5.0",
+				"jest-jasmine2": "^23.5.0",
+				"jest-leak-detector": "^23.5.0",
 				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.4.2",
+				"jest-runtime": "^23.5.0",
 				"jest-util": "^23.4.0",
 				"jest-worker": "^23.2.0",
 				"source-map-support": "^0.5.6",
@@ -5418,9 +5507,9 @@
 			},
 			"dependencies": {
 				"source-map-support": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -5430,9 +5519,9 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.2.tgz",
-			"integrity": "sha512-qaUDOi7tcdDe3MH5g5ycEslTpx0voPZvzIYbKjvWxCzCL2JEemLM+7IEe0BeLi2v5wvb/uh3dkb2wQI67uPtCw==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.5.0.tgz",
+			"integrity": "sha512-WzzYxYtoU8S1MJns0G4E3BsuFUTFBiu1qsk3iC9OTugzNQcQKt0BoOGsT7wXCKqkw/09QdV77vvaeJXST2Efgg==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
@@ -5442,14 +5531,14 @@
 				"exit": "^0.1.2",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.2",
-				"jest-haste-map": "^23.4.1",
+				"jest-config": "^23.5.0",
+				"jest-haste-map": "^23.5.0",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.1",
-				"jest-snapshot": "^23.4.2",
+				"jest-resolve": "^23.5.0",
+				"jest-snapshot": "^23.5.0",
 				"jest-util": "^23.4.0",
-				"jest-validate": "^23.4.0",
+				"jest-validate": "^23.5.0",
 				"micromatch": "^2.3.11",
 				"realpath-native": "^1.0.0",
 				"slash": "^1.0.0",
@@ -5665,20 +5754,20 @@
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-			"integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+			"integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
 			"dev": true,
 			"requires": {
 				"babel-types": "^6.0.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^23.2.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-diff": "^23.5.0",
+				"jest-matcher-utils": "^23.5.0",
 				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.4.1",
+				"jest-resolve": "^23.5.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.2.0",
+				"pretty-format": "^23.5.0",
 				"semver": "^5.5.0"
 			}
 		},
@@ -5699,15 +5788,15 @@
 			}
 		},
 		"jest-validate": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-			"integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+			"integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.5.0"
 			}
 		},
 		"jest-watcher": {
@@ -5810,14 +5899,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -5828,11 +5909,6 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -6298,9 +6374,9 @@
 			}
 		},
 		"node-gyp": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
-			"integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"requires": {
 				"fstream": "^1.0.0",
 				"glob": "^7.0.3",
@@ -6309,57 +6385,13 @@
 				"nopt": "2 || 3",
 				"npmlog": "0 || 1 || 2 || 3 || 4",
 				"osenv": "0",
-				"request": ">=2.9.0 <2.82.0",
+				"request": "^2.87.0",
 				"rimraf": "2",
 				"semver": "~5.3.0",
 				"tar": "^2.0.0",
 				"which": "1"
 			},
 			"dependencies": {
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"qs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-				},
-				"request": {
-					"version": "2.81.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
-					}
-				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -7004,11 +7036,6 @@
 				"through": "~2.3"
 			}
 		},
-		"performance-now": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -7101,9 +7128,9 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-			"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+			"integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
@@ -8010,14 +8037,6 @@
 				}
 			}
 		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"requires": {
-				"hoek": "2.x.x"
-			}
-		},
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -8241,11 +8260,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
-		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -8838,20 +8852,12 @@
 			"dev": true
 		},
 		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+			"integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "0.4.19"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-					"dev": true
-				}
+				"iconv-lite": "0.4.23"
 			}
 		},
 		"whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@gov.au/inpage-nav": "latest",
 		"@gov.au/keyword-list": "latest",
 		"@gov.au/link-list": "latest",
+		"@gov.au/main-nav": "latest",
 		"@gov.au/page-alerts": "latest",
 		"@gov.au/progress-indicator": "latest",
 		"@gov.au/responsive-media": "latest",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	],
 	"scripts": {
 		"test": "npm run build && npm run unit-test && npm run integration-test",
-		"unit-test": "jest --forceExit",
+		"unit-test": "jest",
 		"unit-test:detail": "jest --coverage",
 		"unit-test:watch": "jest --watch --coverage",
 		"integration-test": "node __tests__/integration/tester.js",
@@ -79,7 +79,7 @@
 		"copy-dir": "^0.3.0",
 		"del": "^3.0.0",
 		"dirsum": "^0.1.1",
-		"jest-cli": "^23.4.2",
+		"jest-cli": "^23.5.0",
 		"nodemon": "^1.17.5"
 	},
 	"engines": {


### PR DESCRIPTION
@Xochi this PR does the following:
- Updates jest and allows us to remove the `--forceExit` flag.
- Updates the component versions to the latest
- Adds the main navigation
- Fixes vulnerable dependencies

fixes #30 and fixes #33 