### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: sudo apt-get install cf-cli
       - run: cf install-plugin https://github.com/govau/autopilot/releases/download/0.0.5-venapp/autopilot-linux -f
       - run: cf version                # log what version we are running
-      - run: cf login -a api.system.y.cld.gov.au -o $CF_ORG_STAGING -s $CF_SPACE_STAGING -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+      - run: cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
       - run: cf zero-downtime-push furnace -f manifest-staging.yml
 
 
@@ -47,7 +47,7 @@ jobs:
       - run: sudo apt-get install cf-cli
       - run: cf install-plugin https://github.com/govau/autopilot/releases/download/0.0.5-venapp/autopilot-linux -f
       - run: cf version
-      - run: cf login -a api.system.b.cld.gov.au -o $CF_ORG_PROD -s $CF_SPACE_PROD -u $CF_USER_PROD -p $CF_PASSWORD_PROD
+      - run: cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_PROD
       - run: cf zero-downtime-push furnace -f manifest-prod.yml
 
 


### PR DESCRIPTION
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to
make it easier for us we need to have a standard naming convention for environment
variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use
the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent
in the above list.